### PR TITLE
checksum is not available if image is being queued

### DIFF
--- a/rwcal/plugins/vala/rwcal_openstack/rwcal_openstack.py
+++ b/rwcal/plugins/vala/rwcal_openstack/rwcal_openstack.py
@@ -308,7 +308,11 @@ class RwcalOpenstackPlugin(GObject.Object, RwCal.Cloud):
         img = RwcalYang.ImageInfoItem()
         img.name = img_info['name']
         img.id = img_info['id']
-        img.checksum = img_info['checksum']
+        
+        # check if checksum is available. It may not be if image is currently being queued
+        if 'checksum' in img_info:
+            img.checksum = img_info['checksum']
+
         img.disk_format = img_info['disk_format']
         img.container_format = img_info['container_format']
         if img_info['status'] == 'active':


### PR DESCRIPTION
If an image is currently being queued in the stack, this throw will cause all the images to bail with strange errors like "imageinfo_list" not found.